### PR TITLE
feat: add guia travel hub and polish api demos

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,5 +1,4 @@
 // src/components/layout/Header.jsx
-import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { Navbar, Nav, Container } from 'react-bootstrap';
 import ThemeToggle from '../theme/ThemeToggle';

--- a/src/components/sections/ProjectsPreviewSection.css
+++ b/src/components/sections/ProjectsPreviewSection.css
@@ -67,6 +67,21 @@
   box-shadow: 0 2px 4px rgba(0, 150, 57, 0.3);
 }
 
+.gemini-badge {
+  background-color: #9e00ff;
+  box-shadow: 0 2px 4px rgba(158, 0, 255, 0.3);
+}
+
+.aws-badge {
+  background-color: #ff9900;
+  box-shadow: 0 2px 4px rgba(255, 153, 0, 0.3);
+}
+
+.places-badge {
+  background-color: #4285f4;
+  box-shadow: 0 2px 4px rgba(66, 133, 244, 0.3);
+}
+
 .project-features li {
   margin-bottom: 8px;
   position: relative;

--- a/src/components/sections/ProjectsPreviewSection.jsx
+++ b/src/components/sections/ProjectsPreviewSection.jsx
@@ -22,9 +22,22 @@ const ProjectCard = ({ title, description, technologies, features, demoLink }) =
           <li key={index}>{feature}</li>
         ))}
       </ul>
-      <Link to={demoLink} className="project-link">
-        Ver demonstração interativa →
-      </Link>
+      {demoLink && (
+        demoLink.startsWith('http') ? (
+          <a
+            href={demoLink}
+            className="project-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Ver demonstração interativa →
+          </a>
+        ) : (
+          <Link to={demoLink} className="project-link">
+            Ver demonstração interativa →
+          </Link>
+        )
+      )}
     </Card.Body>
   </Card>
 );
@@ -32,8 +45,27 @@ const ProjectCard = ({ title, description, technologies, features, demoLink }) =
 const ProjectsPreviewSection = () => {
   const projects = [
     {
+      title: 'Guia Travel Hub',
+      description:
+        'Sistema de geração e recomendação de roteiros de viagens usando IA para criar itinerários personalizados.',
+      technologies: [
+        { name: 'Go', badge: 'go-badge' },
+        { name: 'Gemini', badge: 'gemini-badge' },
+        { name: 'Amazon AWS (EC2, S3)', badge: 'aws-badge' },
+        { name: 'Google Places API', badge: 'places-badge' }
+      ],
+      features: [
+        'Geração automática de roteiros com IA Gemini',
+        'Recomendações com dados da Google Places API',
+        'Infraestrutura escalável em EC2 e armazenamento no S3',
+        'Exportação e compartilhamento de itinerários'
+      ],
+      demoLink: 'https://github.com/Ulpio/guia-travel-hub'
+    },
+    {
       title: 'Plataforma Registartt',
-      description: 'Desenvolvimento de backend para a plataforma online da Registartt, proporcionando um sistema robusto e escalável para gerenciamento de registros.',
+      description:
+        'Desenvolvimento de backend para a plataforma online da Registartt, proporcionando um sistema robusto e escalável para gerenciamento de registros.',
       technologies: [
         { name: 'Go', badge: 'go-badge' },
         { name: 'PostgreSQL', badge: 'postgres-badge' },
@@ -50,7 +82,8 @@ const ProjectsPreviewSection = () => {
     },
     {
       title: 'Impulsa Brasil',
-      description: 'Sistema em desenvolvimento para impulsionar negócios brasileiros, oferecendo ferramentas digitais para crescimento e gestão.',
+      description:
+        'Sistema em desenvolvimento para impulsionar negócios brasileiros, oferecendo ferramentas digitais para crescimento e gestão.',
       technologies: [
         { name: 'Go', badge: 'go-badge' },
         { name: 'MongoDB', badge: 'mongo-badge' },

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,18 @@ body {
   background-color: #009639;
 }
 
+.gemini-badge {
+  background-color: #9e00ff;
+}
+
+.aws-badge {
+  background-color: #ff9900;
+}
+
+.places-badge {
+  background-color: #4285f4;
+}
+
 .docker-badge {
   background-color: #2496ED;
 }

--- a/src/pages/PlaygroundPage.jsx
+++ b/src/pages/PlaygroundPage.jsx
@@ -86,7 +86,7 @@ const RegistarttDemo = () => {
               prioridade: requestData.prioridade || 1
             }
           };
-        } catch (error) {
+        } catch {
           responseContent = {
             status: '400 Bad Request',
             time: `${randomResponseTime}ms`,
@@ -298,7 +298,7 @@ const ImpulsaDemo = () => {
               }
             }
           };
-        } catch (error) {
+        } catch {
           responseContent = {
             status: '400 Bad Request',
             time: `${randomResponseTime}ms`,
@@ -360,12 +360,13 @@ const ImpulsaDemo = () => {
           <Form.Label className="fw-medium">Resposta</Form.Label>
           <div className="response-container">
             {response ? (
-              <pre className="mb-0 response-content">
-                {`Status: ${response.status}
-Tempo de resposta: ${response.time}
-
-${JSON.stringify(response.data || response.error, null, 2)}`}
-              </pre>
+              <>
+                <div className="response-status">Status: {response.status}</div>
+                <div className="response-time">Tempo de resposta: {response.time}</div>
+                <pre className="response-content">
+                  {JSON.stringify(response.data || response.error, null, 2)}
+                </pre>
+              </>
             ) : (
               <p className="text-muted mb-0 response-placeholder">Envie uma requisição para ver a resposta aqui.</p>
             )}
@@ -399,7 +400,8 @@ const PlaygroundPage = () => {
       <Container>
         <h1 className="text-center fw-bold mb-2">APIs Interativas</h1>
         <p className="text-center text-muted mb-5 mx-auto" style={{ maxWidth: '700px' }}>
-          Experimente demonstrações interativas das APIs que desenvolvi usando Go, PostgreSQL e MongoDB.
+          Experimente demonstrações interativas das APIs que desenvolvi usando Go, PostgreSQL e MongoDB. As respostas abaixo
+          são simuladas para refletir a estrutura e a performance das implementações reais.
         </p>
         
         <Tab.Container activeKey={activeTab} onSelect={setActiveTab}>

--- a/src/pages/ProjectsPage.jsx
+++ b/src/pages/ProjectsPage.jsx
@@ -7,10 +7,10 @@ const ProjectCard = ({ title, description, technologies, features, demoLink, ima
   <Card className="h-100 project-card">
     {imageUrl && (
       <div className="bg-light" style={{ height: '200px' }}>
-        <Card.Img 
-          variant="top" 
-          src={imageUrl} 
-          alt={title} 
+        <Card.Img
+          variant="top"
+          src={imageUrl}
+          alt={title}
           style={{ height: '100%', objectFit: 'cover' }}
         />
       </div>
@@ -20,8 +20,8 @@ const ProjectCard = ({ title, description, technologies, features, demoLink, ima
       <Card.Text className="text-muted mb-3">{description}</Card.Text>
       <div className="mb-3">
         {technologies.map((tech, index) => (
-          <span 
-            key={index} 
+          <span
+            key={index}
             className={`tech-badge ${tech.badge || ''}`}
           >
             {tech.name}
@@ -34,12 +34,22 @@ const ProjectCard = ({ title, description, technologies, features, demoLink, ima
           <li key={index}>{feature}</li>
         ))}
       </ul>
-      <Link 
-        to={demoLink}
-        className="text-decoration-none"
-      >
-        Ver demonstração interativa →
-      </Link>
+      {demoLink && (
+        demoLink.startsWith('http') ? (
+          <a
+            href={demoLink}
+            className="text-decoration-none"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Ver demonstração interativa →
+          </a>
+        ) : (
+          <Link to={demoLink} className="text-decoration-none">
+            Ver demonstração interativa →
+          </Link>
+        )
+      )}
     </Card.Body>
   </Card>
 );
@@ -52,8 +62,28 @@ const ProjectsPage = () => {
 
   const projects = [
     {
+      title: 'Guia Travel Hub',
+      description:
+        'Sistema de geração e recomendação de roteiros de viagens usando IA para criar itinerários personalizados.',
+      technologies: [
+        { name: 'Go', badge: 'go-badge' },
+        { name: 'Gemini', badge: 'gemini-badge' },
+        { name: 'Amazon AWS (EC2, S3)', badge: 'aws-badge' },
+        { name: 'Google Places API', badge: 'places-badge' }
+      ],
+      features: [
+        'Geração automática de roteiros com IA Gemini',
+        'Recomendações com dados da Google Places API',
+        'Infraestrutura em EC2 com arquivos no S3',
+        'Exportação e compartilhamento de itinerários',
+        'Interface responsiva e intuitiva'
+      ],
+      demoLink: 'https://github.com/Ulpio/guia-travel-hub'
+    },
+    {
       title: 'Plataforma Registartt',
-      description: 'Desenvolvimento de backend para a plataforma online da Registartt, proporcionando um sistema robusto e escalável para gerenciamento de registros.',
+      description:
+        'Desenvolvimento de backend para a plataforma online da Registartt, proporcionando um sistema robusto e escalável para gerenciamento de registros.',
       technologies: [
         { name: 'Go', badge: 'go-badge' },
         { name: 'PostgreSQL', badge: 'postgres-badge' },
@@ -73,7 +103,8 @@ const ProjectsPage = () => {
     },
     {
       title: 'Impulsa Brasil',
-      description: 'Sistema em desenvolvimento para impulsionar negócios brasileiros, oferecendo ferramentas digitais para crescimento e gestão.',
+      description:
+        'Sistema em desenvolvimento para impulsionar negócios brasileiros, oferecendo ferramentas digitais para crescimento e gestão.',
       technologies: [
         { name: 'Go', badge: 'go-badge' },
         { name: 'MongoDB', badge: 'mongo-badge' },
@@ -93,7 +124,8 @@ const ProjectsPage = () => {
     },
     {
       title: 'OxeTech',
-      description: 'Plataforma do Programa do Governo do Estado de Alagoas, democratizando o acesso ao ensino de tecnologia e desenvolvimento.',
+      description:
+        'Plataforma do Programa do Governo do Estado de Alagoas, democratizando o acesso ao ensino de tecnologia e desenvolvimento.',
       technologies: [
         { name: 'Go', badge: 'go-badge' },
         { name: 'JavaScript', badge: 'js-badge' },


### PR DESCRIPTION
## Summary
- feature: showcase Guia Travel Hub project with tech stack and link handling
- chore: improve API playground messaging and response formatting for credibility
- chore: update Guia Travel Hub stack to Go, Gemini, AWS and Google Places with matching badges

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891ae5bea348324b9651c4f57f85e18