### PR TITLE
feat: clarify freelance/personal roles, add languages, and English pr…

### DIFF
--- a/src/components/cv/CVDocument.jsx
+++ b/src/components/cv/CVDocument.jsx
@@ -240,11 +240,12 @@ const labels = {
     experience: 'Professional Experience',
     education:  'Education',
     projects:   'Key Projects',
-    languages:  'Languages',
+    langSkills: 'Languages',
     databases:  'Databases',
     frameworks: 'Frameworks & Tools',
     devops:     'DevOps & Cloud',
     practices:  'Architecture & Practices',
+    spokenLangs: 'Languages',
     docTitle:   'Resume - Ulpio Netto - Backend Developer',
     docSubject: 'Resume of Ulpio Netto, Backend Developer and Software Engineer specializing in Go, Java, REST APIs, microservices, AWS, Kubernetes, and cloud infrastructure.',
     generated:  'Generated from ulpionetto.dev',
@@ -255,11 +256,12 @@ const labels = {
     experience: 'Experi\u00eancia Profissional',
     education:  'Forma\u00e7\u00e3o Acad\u00eamica',
     projects:   'Projetos Relevantes',
-    languages:  'Linguagens',
+    langSkills: 'Linguagens',
     databases:  'Bancos de Dados',
     frameworks: 'Frameworks & Ferramentas',
     devops:     'DevOps & Cloud',
     practices:  'Arquitetura & Pr\u00e1ticas',
+    spokenLangs: 'Idiomas',
     docTitle:   'Curr\u00edculo - Ulpio Netto - Desenvolvedor Backend',
     docSubject: 'Curr\u00edculo de Ulpio Netto, Desenvolvedor Backend e Engenheiro de Software especializado em Go, Java, APIs REST, microsservi\u00e7os, AWS, Kubernetes e infraestrutura cloud.',
     generated:  'Gerado a partir de ulpionetto.dev',
@@ -369,7 +371,7 @@ function CVDocument({ lang = 'en' }) {
           {/* Row 1: Languages | Databases */}
           <View style={s.skillRow}>
             <View style={s.skillColLeft}>
-              <Text style={s.skillCatTitle}>{l.languages}</Text>
+              <Text style={s.skillCatTitle}>{l.langSkills}</Text>
               <Text style={s.skillLine}>{skills.languages.join(', ')}</Text>
             </View>
             <View style={s.skillColRight}>
@@ -409,7 +411,9 @@ function CVDocument({ lang = 'en' }) {
                   <Text style={s.expRole}>{role}</Text>
                   <Text style={s.expPeriod}>{locPeriod(exp.period, lang)}</Text>
                 </View>
-                <Text style={s.expCompany}>{exp.company}</Text>
+                <Text style={s.expCompany}>
+                  {exp.company}{exp.type ? ` — ${loc(exp.type, lang)}` : ''}
+                </Text>
                 {highlights.map((line, j) => (
                   <View key={j} style={s.expBullet}>
                     <Text style={s.expBulletDot}>{'\u2022'}</Text>
@@ -442,6 +446,18 @@ function CVDocument({ lang = 'en' }) {
                 </View>
               );
             })}
+          </View>
+        )}
+
+        {/* ── LANGUAGES ── */}
+        {cvData.languages && cvData.languages.length > 0 && (
+          <View style={s.section}>
+            <Text style={s.sectionTitle}>{l.spokenLangs}</Text>
+            <Text style={s.skillLine}>
+              {cvData.languages.map((lg) =>
+                `${loc(lg.lang, lang)} (${loc(lg.level, lang)})`
+              ).join('  •  ')}
+            </Text>
           </View>
         )}
 

--- a/src/data/cvData.js
+++ b/src/data/cvData.js
@@ -90,20 +90,21 @@ export const cvData = {
     {
       slug: 'guia',
       company: 'guIA Travel Hub',
+      type: { en: 'Freelance', pt: 'Freelance' },
       period: '2025',
       role: {
-        en: 'Backend Developer | Software Engineer',
-        pt: 'Desenvolvedor Backend | Engenheiro de Software',
+        en: 'Freelance Backend Developer',
+        pt: 'Desenvolvedor Backend Freelance',
       },
       highlights: {
         en: [
-          'Architected and developed REST APIs in Go/Java for an AI-powered travel itinerary platform',
+          'Hired to architect and deliver the MVP backend in Go/Java for an AI-powered travel itinerary platform',
           'Built dynamic itinerary generation engine integrating external tourism APIs and AI recommendations',
           'Designed PostgreSQL schema for multi-profile user management (travelers, agencies)',
           'Deployed on AWS EC2 with S3 for asset storage and automated CI/CD pipelines',
         ],
         pt: [
-          'Arquitetei e desenvolvi APIs REST em Go/Java para plataforma de roteiros de viagem com IA',
+          'Contratado para arquitetar e entregar o MVP backend em Go/Java para plataforma de roteiros de viagem com IA',
           'Constru\u00ed motor de gera\u00e7\u00e3o din\u00e2mica de itiner\u00e1rios integrando APIs externas de turismo e recomenda\u00e7\u00f5es de IA',
           'Projetei schema PostgreSQL para gest\u00e3o de usu\u00e1rios multi-perfil (viajantes, ag\u00eancias)',
           'Deploy em AWS EC2 com S3 para armazenamento de assets e pipelines CI/CD automatizados',
@@ -112,7 +113,8 @@ export const cvData = {
     },
     {
       slug: 'vergo',
-      company: 'Vergo (Open Source)',
+      company: 'Vergo',
+      type: { en: 'Personal Project', pt: 'Projeto Pessoal' },
       period: '2025',
       role: {
         en: 'Creator & Lead Developer',
@@ -120,12 +122,12 @@ export const cvData = {
       },
       highlights: {
         en: [
-          'Created open-source multi-tenant SaaS boilerplate in Go with RBAC, JWT authentication, and Stripe billing',
+          'Created a production-grade SaaS foundation in Go featuring multi-tenancy, RBAC, JWT auth, and Stripe billing — designed as a reusable base for any SaaS product',
           'Implemented secure file handling with AWS S3 presigned URLs and project CRUD with full audit logging',
-          'Set up CI/CD with GitHub Actions, Dependabot for dependency updates, and CodeQL for security scanning',
+          'Engineered CI/CD with GitHub Actions, Dependabot, and CodeQL security scanning; open-sourced as a reference architecture',
         ],
         pt: [
-          'Criei boilerplate SaaS multi-tenant open-source em Go com RBAC, autentica\u00e7\u00e3o JWT e billing Stripe',
+          'Criei uma base SaaS production-grade em Go com multi-tenancy, RBAC, auth JWT e billing Stripe — projetada como fundação reutilizável para qualquer produto SaaS',
           'Implementei manipula\u00e7\u00e3o segura de arquivos com AWS S3 presigned URLs e CRUD de projetos com audit log completo',
           'Configurei CI/CD com GitHub Actions, Dependabot para atualiza\u00e7\u00f5es e CodeQL para an\u00e1lise de seguran\u00e7a',
         ],
@@ -177,6 +179,12 @@ export const cvData = {
         ],
       },
     },
+  ],
+
+  languages: [
+    { lang: { en: 'Portuguese', pt: 'Português' }, level: { en: 'Native', pt: 'Nativo' } },
+    { lang: { en: 'English', pt: 'Inglês' }, level: { en: 'Fluent', pt: 'Fluente' } },
+    { lang: { en: 'Mandarin Chinese', pt: 'Mandarim' }, level: { en: 'Beginner (studying)', pt: 'Iniciante (estudando)' } },
   ],
 
   projects: projects.map((p) => ({

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -9,7 +9,7 @@
   },
   "hero": {
     "badge": "Open to opportunities",
-    "subtitle": "Backend Developer \u00b7 Go & Java",
+    "subtitle": "Backend Developer · Go & Java",
     "bio": "Software Engineer with 5+ years of experience building high-throughput REST APIs, microservices at scale, and cloud infrastructure. Go, Java, PostgreSQL, Kubernetes, and AWS are my daily stack.",
     "viewProjects": "View Projects",
     "getInTouch": "Get in Touch",
@@ -35,7 +35,8 @@
       "location": "\"Brazil\"",
       "email": "\"ulpionetto0@gmail.com\"",
       "stack": "\"Go, Java, AWS, K8s\"",
-      "openTo": "\"new opportunities\""
+      "openTo": "\"new opportunities\"",
+      "languages": "\"EN (Fluent), 中文 (Learning)\""
     },
     "terminalAria": "Contact information in terminal style"
   },
@@ -143,15 +144,20 @@
         ]
       },
       "guia": {
-        "role": "Backend Developer | Software Engineer",
+        "role": "Freelance Backend Developer",
         "highlights": [
-          "Built guIA Travel Hub backend; REST APIs in Go/Java; PostgreSQL; microservices; AWS"
+          "Hired to architect and deliver the MVP backend in Go/Java for an AI-powered travel itinerary platform",
+          "Built dynamic itinerary generation engine integrating external tourism APIs and AI recommendations",
+          "Designed PostgreSQL schema for multi-profile user management (travelers, agencies)",
+          "Deployed on AWS EC2 with S3 for asset storage and automated CI/CD pipelines"
         ]
       },
       "vergo": {
-        "role": "Backend Developer | Software Engineer",
+        "role": "Creator & Lead Developer",
         "highlights": [
-          "Backend development; REST APIs; microservices architecture; Docker; CI/CD"
+          "Created a production-grade SaaS foundation in Go featuring multi-tenancy, RBAC, JWT auth, and Stripe billing — designed as a reusable base for any SaaS product",
+          "Implemented secure file handling with AWS S3 presigned URLs and project CRUD with full audit logging",
+          "Engineered CI/CD with GitHub Actions, Dependabot, and CodeQL security scanning; open-sourced as a reference architecture"
         ]
       },
       "registartt": {
@@ -166,7 +172,9 @@
           "Backend and microservices; Go, Java, and Node.js; REST APIs; PostgreSQL; Docker; Kubernetes; AWS; CI/CD; team lead"
         ]
       }
-    }
+    },
+    "freelance": "Freelance",
+    "personalProject": "Personal Project"
   },
   "contact": {
     "label": "// contact",
@@ -206,7 +214,17 @@
     "switchToDark": "Switch to dark mode"
   },
   "seo": {
-    "title": "Ulpio Netto \u2013 Backend Developer | Go & Java | Software Engineer",
+    "title": "Ulpio Netto – Backend Developer | Go & Java | Software Engineer",
     "description": "Portfolio of Ulpio Netto, Backend Developer with 5+ years of experience in Go, Java, REST APIs, microservices, Docker, Kubernetes, and AWS."
+  },
+  "languages": {
+    "label": "// languages",
+    "title": "Languages",
+    "portuguese": "Portuguese",
+    "english": "English",
+    "mandarin": "Mandarin Chinese",
+    "native": "Native",
+    "fluent": "Fluent",
+    "beginner": "Beginner (studying)"
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3,41 +3,42 @@
     "about": "Sobre",
     "skills": "Skills",
     "projects": "Projetos",
-    "experience": "Experi\u00eancia",
+    "experience": "Experiência",
     "contact": "Contato",
     "backToTop": "Ulpio Netto - voltar ao topo"
   },
   "hero": {
-    "badge": "Dispon\u00edvel para oportunidades",
-    "subtitle": "Desenvolvedor Backend \u00b7 Go & Java",
-    "bio": "Engenheiro de Software com 5+ anos de experi\u00eancia construindo APIs REST, microsservi\u00e7os e infraestrutura cloud. Go, Java, PostgreSQL, Kubernetes e AWS s\u00e3o minha stack di\u00e1ria.",
+    "badge": "Disponível para oportunidades",
+    "subtitle": "Desenvolvedor Backend · Go & Java",
+    "bio": "Engenheiro de Software com 5+ anos de experiência construindo APIs REST, microsserviços e infraestrutura cloud. Go, Java, PostgreSQL, Kubernetes e AWS são minha stack diária.",
     "viewProjects": "Ver Projetos",
     "getInTouch": "Entrar em Contato",
     "downloadCV": "Baixar CV",
     "generatingCV": "Gerando...",
     "githubAria": "GitHub de Ulpio Netto",
     "linkedinAria": "LinkedIn de Ulpio Netto",
-    "scrollAria": "Rolar para a se\u00e7\u00e3o Sobre"
+    "scrollAria": "Rolar para a seção Sobre"
   },
   "about": {
     "label": "// about me",
     "title": "Sobre mim",
-    "p1": "Desenvolvedor Backend e Engenheiro de Software com foco em Go (Golang), Java, APIs REST e arquitetura de microsservi\u00e7os. Experi\u00eancia s\u00f3lida com Docker, Kubernetes, AWS, PostgreSQL e pipelines de CI/CD.",
-    "p2": "Constru\u00ed backends de plataformas como Registartt e guIA Travel Hub do zero; atuo em projetos como OxeTech, SonorIA e Yes Technology. Experi\u00eancia em migra\u00e7\u00e3o de bases legadas, design de APIs REST e gest\u00e3o de times como team lead.",
-    "p3": "Stack principal: Go, Java, Node.js, PostgreSQL, MongoDB, AWS, Docker, Kubernetes, Terraform e pr\u00e1ticas de DevOps para entregas seguras e previs\u00edveis.",
+    "p1": "Desenvolvedor Backend e Engenheiro de Software com foco em Go (Golang), Java, APIs REST e arquitetura de microsserviços. Experiência sólida com Docker, Kubernetes, AWS, PostgreSQL e pipelines de CI/CD.",
+    "p2": "Construí backends de plataformas como Registartt e guIA Travel Hub do zero; atuo em projetos como OxeTech, SonorIA e Yes Technology. Experiência em migração de bases legadas, design de APIs REST e gestão de times como team lead.",
+    "p3": "Stack principal: Go, Java, Node.js, PostgreSQL, MongoDB, AWS, Docker, Kubernetes, Terraform e práticas de DevOps para entregas seguras e previsíveis.",
     "stats": {
-      "years": "anos de experi\u00eancia",
+      "years": "anos de experiência",
       "projects": "projetos entregues",
-      "users": "usu\u00e1rios impactados",
-      "countries": "pa\u00edses atendidos"
+      "users": "usuários impactados",
+      "countries": "países atendidos"
     },
     "terminal": {
       "location": "\"Brasil\"",
       "email": "\"ulpionetto0@gmail.com\"",
       "stack": "\"Go, Java, AWS, K8s\"",
-      "openTo": "\"novas oportunidades\""
+      "openTo": "\"novas oportunidades\"",
+      "languages": "\"EN (Fluente), 中文 (Estudando)\""
     },
-    "terminalAria": "Informa\u00e7\u00f5es de contato em estilo terminal"
+    "terminalAria": "Informações de contato em estilo terminal"
   },
   "skills": {
     "label": "// skills",
@@ -61,97 +62,102 @@
   },
   "projectData": {
     "registartt": {
-      "description": "Desenvolvimento de backend para a plataforma online da Registartt, proporcionando um sistema robusto e escal\u00e1vel para gerenciamento de registros.",
+      "description": "Desenvolvimento de backend para a plataforma online da Registartt, proporcionando um sistema robusto e escalável para gerenciamento de registros.",
       "features": [
         "API RESTful de alta performance",
-        "Sistema de autentica\u00e7\u00e3o e autoriza\u00e7\u00e3o",
-        "Cache distribu\u00eddo para melhor desempenho",
-        "Processamento ass\u00edncrono de tarefas",
+        "Sistema de autenticação e autorização",
+        "Cache distribuído para melhor desempenho",
+        "Processamento assíncrono de tarefas",
         "Logs estruturados e monitoramento",
-        "Documenta\u00e7\u00e3o interativa da API"
+        "Documentação interativa da API"
       ]
     },
     "vergo": {
-      "description": "Boilerplate SaaS open source em Go, com foco em multi-tenant, RBAC, autentica\u00e7\u00e3o JWT, integra\u00e7\u00e3o com Postgres/sqlc, S3 e Stripe. Projetado para demonstrar boas pr\u00e1ticas de arquitetura, seguran\u00e7a e CI/CD.",
+      "description": "Boilerplate SaaS open source em Go, com foco em multi-tenant, RBAC, autenticação JWT, integração com Postgres/sqlc, S3 e Stripe. Projetado para demonstrar boas práticas de arquitetura, segurança e CI/CD.",
       "features": [
-        "Autentica\u00e7\u00e3o JWT (login, signup, refresh)",
-        "RBAC (controle de acesso baseado em pap\u00e9is)",
-        "Multi-tenant (isolamento de organiza\u00e7\u00f5es)",
-        "Integra\u00e7\u00e3o com AWS S3 via presigned URLs",
-        "Integra\u00e7\u00e3o com Stripe para billing",
+        "Autenticação JWT (login, signup, refresh)",
+        "RBAC (controle de acesso baseado em papéis)",
+        "Multi-tenant (isolamento de organizações)",
+        "Integração com AWS S3 via presigned URLs",
+        "Integração com Stripe para billing",
         "CRUD de projetos com audit log",
         "CI/CD com GitHub Actions (build + test)",
-        "Dependabot e CodeQL para seguran\u00e7a e atualiza\u00e7\u00e3o"
+        "Dependabot e CodeQL para segurança e atualização"
       ]
     },
     "oxetech": {
       "description": "Plataforma do Programa do Governo do Estado de Alagoas, democratizando o acesso ao ensino de tecnologia e desenvolvimento.",
       "features": [
-        "Transcri\u00e7\u00e3o da API original de JS para Go",
+        "Transcrição da API original de JS para Go",
         "Processamento de dados em tempo real",
-        "Diferentes n\u00edveis de acesso e l\u00f3gicas de neg\u00f3cio",
-        "Tempos de resposta at\u00e9 75% mais velozes",
-        "API organizada e de f\u00e1cil manuten\u00e7\u00e3o"
+        "Diferentes níveis de acesso e lógicas de negócio",
+        "Tempos de resposta até 75% mais velozes",
+        "API organizada e de fácil manutenção"
       ]
     },
     "guia": {
       "description": "Hub de turismo inteligente que utiliza IA para montar roteiros de viagem personalizados a partir do perfil do viajante.",
       "features": [
-        "Cria\u00e7\u00e3o de roteiros din\u00e2micos com base em prefer\u00eancias e or\u00e7amento",
-        "Exporta\u00e7\u00e3o de itiner\u00e1rios completos em PDF",
-        "Cadastro e gest\u00e3o de perfis de viajantes",
-        "Sugest\u00f5es inteligentes de hot\u00e9is, restaurantes e atra\u00e7\u00f5es",
-        "Integra\u00e7\u00e3o com APIs externas para dados atualizados de turismo",
-        "Organiza\u00e7\u00e3o di\u00e1ria do roteiro com dicas locais"
+        "Criação de roteiros dinâmicos com base em preferências e orçamento",
+        "Exportação de itinerários completos em PDF",
+        "Cadastro e gestão de perfis de viajantes",
+        "Sugestões inteligentes de hotéis, restaurantes e atrações",
+        "Integração com APIs externas para dados atualizados de turismo",
+        "Organização diária do roteiro com dicas locais"
       ]
     },
     "yes": {
-      "description": "Plataforma corporativa de microsservi\u00e7os em Go para gera\u00e7\u00e3o de relat\u00f3rios (PDF/XLS) integrada a um motor BPMN, com arquitetura distribu\u00edda e deploy automatizado em Kubernetes na AWS.",
+      "description": "Plataforma corporativa de microsserviços em Go para geração de relatórios (PDF/XLS) integrada a um motor BPMN, com arquitetura distribuída e deploy automatizado em Kubernetes na AWS.",
       "features": [
-        "Motor BPMN para orquestra\u00e7\u00e3o de processos de neg\u00f3cio",
-        "Gera\u00e7\u00e3o ass\u00edncrona de relat\u00f3rios em PDF e XLS",
-        "Comunica\u00e7\u00e3o entre microsservi\u00e7os via AWS SQS/SNS",
+        "Motor BPMN para orquestração de processos de negócio",
+        "Geração assíncrona de relatórios em PDF e XLS",
+        "Comunicação entre microsserviços via AWS SQS/SNS",
         "Armazenamento de artefatos em AWS S3",
         "Deploy em Kubernetes via ArgoCD (GitOps)",
-        "Infraestrutura como c\u00f3digo com Terraform",
+        "Infraestrutura como código com Terraform",
         "Observabilidade com OpenTelemetry e Jaeger"
       ]
     },
     "sonoria": {
-      "description": "Plataforma web com IA para an\u00e1lise automatizada de exames eletrofisiol\u00f3gicos auditivos (PEATE, PEAC, VEMP), auxiliando profissionais de sa\u00fade na tomada de decis\u00e3o cl\u00ednica.",
+      "description": "Plataforma web com IA para análise automatizada de exames eletrofisiológicos auditivos (PEATE, PEAC, VEMP), auxiliando profissionais de saúde na tomada de decisão clínica.",
       "features": [
-        "An\u00e1lise automatizada de exames auditivos com IA (modelo CRNN)",
+        "Análise automatizada de exames auditivos com IA (modelo CRNN)",
         "Upload e processamento de arquivos de exame (.txt)",
-        "Marca\u00e7\u00e3o de picos e ondas manual e assistida por IA",
-        "Visualiza\u00e7\u00e3o interativa de formas de onda",
-        "Autentica\u00e7\u00e3o com perfis (profissional, estudante, professor)",
-        "Migra\u00e7\u00e3o de dados de sistemas legados (EPWin)"
+        "Marcação de picos e ondas manual e assistida por IA",
+        "Visualização interativa de formas de onda",
+        "Autenticação com perfis (profissional, estudante, professor)",
+        "Migração de dados de sistemas legados (EPWin)"
       ]
     }
   },
   "experience": {
     "label": "// experience",
-    "title": "Experi\u00eancia",
-    "subtitle": "Trajet\u00f3ria profissional em ordem cronol\u00f3gica reversa.",
+    "title": "Experiência",
+    "subtitle": "Trajetória profissional em ordem cronológica reversa.",
     "highlightsAria": "Destaques",
-    "timelineAria": "Hist\u00f3rico de experi\u00eancia profissional",
+    "timelineAria": "Histórico de experiência profissional",
     "roles": {
       "yes": {
         "role": "Desenvolvedor Backend | Engenheiro de Software",
         "highlights": [
-          "Backend em Go (Golang) e Java; APIs REST; microsservi\u00e7os; Docker e Kubernetes; AWS; CI/CD."
+          "Backend em Go (Golang) e Java; APIs REST; microsserviços; Docker e Kubernetes; AWS; CI/CD."
         ]
       },
       "guia": {
-        "role": "Desenvolvedor Backend | Engenheiro de Software",
+        "role": "Desenvolvedor Backend Freelance",
         "highlights": [
-          "Backend do guIA Travel Hub; APIs REST; Go/Java; PostgreSQL; microsservi\u00e7os; AWS."
+          "Contratado para arquitetar e entregar o MVP backend em Go/Java para plataforma de roteiros de viagem com IA",
+          "Construí motor de geração dinâmica de itinerários integrando APIs externas de turismo e recomendações de IA",
+          "Projetei schema PostgreSQL para gestão de usuários multi-perfil (viajantes, agências)",
+          "Deploy em AWS EC2 com S3 para armazenamento de assets e pipelines CI/CD automatizados"
         ]
       },
       "vergo": {
-        "role": "Desenvolvedor Backend | Engenheiro de Software",
+        "role": "Criador & Desenvolvedor Líder",
         "highlights": [
-          "Desenvolvimento backend; APIs REST; arquitetura de microsservi\u00e7os; Docker; CI/CD."
+          "Criei uma base SaaS production-grade em Go com multi-tenancy, RBAC, auth JWT e billing Stripe — projetada como fundação reutilizável para qualquer produto SaaS",
+          "Implementei manipulação segura de arquivos com AWS S3 presigned URLs e CRUD de projetos com audit log completo",
+          "Implementei CI/CD com GitHub Actions, Dependabot e CodeQL para segurança; open-source como arquitetura de referência"
         ]
       },
       "registartt": {
@@ -163,29 +169,31 @@
       "oxetech": {
         "role": "Desenvolvedor Backend | Engenheiro de Software",
         "highlights": [
-          "Backend e microsservi\u00e7os; Go, Java e Node.js; APIs REST; PostgreSQL; Docker; Kubernetes; AWS; CI/CD; atua\u00e7\u00e3o como team lead."
+          "Backend e microsserviços; Go, Java e Node.js; APIs REST; PostgreSQL; Docker; Kubernetes; AWS; CI/CD; atuação como team lead."
         ]
       }
-    }
+    },
+    "freelance": "Freelance",
+    "personalProject": "Projeto Pessoal"
   },
   "contact": {
     "label": "// contact",
     "title": "Contato",
     "subtitle": "Tem um projeto em mente ou quer conversar sobre uma oportunidade? Entre em contato!",
-    "formAria": "Formul\u00e1rio de contato",
+    "formAria": "Formulário de contato",
     "nameLabel": "Nome *",
     "namePlaceholder": "Seu nome",
     "emailLabel": "Email *",
     "emailPlaceholder": "seu@email.com",
     "messageLabel": "Mensagem *",
-    "messagePlaceholder": "Ol\u00e1! Gostaria de conversar sobre...",
+    "messagePlaceholder": "Olá! Gostaria de conversar sobre...",
     "submit": "Enviar mensagem",
     "sending": "Enviando...",
     "errors": {
-      "nameRequired": "Nome \u00e9 obrigat\u00f3rio",
-      "emailRequired": "Email \u00e9 obrigat\u00f3rio",
-      "emailInvalid": "Email inv\u00e1lido",
-      "messageRequired": "Mensagem \u00e9 obrigat\u00f3ria"
+      "nameRequired": "Nome é obrigatório",
+      "emailRequired": "Email é obrigatório",
+      "emailInvalid": "Email inválido",
+      "messageRequired": "Mensagem é obrigatória"
     },
     "success": "Mensagem enviada com sucesso!",
     "error": "Falha ao enviar mensagem. Tente novamente."
@@ -199,14 +207,24 @@
     "emailAria": "Enviar email para Ulpio Netto"
   },
   "a11y": {
-    "skipToContent": "Pular para o conte\u00fado principal",
+    "skipToContent": "Pular para o conteúdo principal",
     "openMenu": "Abrir menu",
     "closeMenu": "Fechar menu",
     "switchToLight": "Mudar para modo claro",
     "switchToDark": "Mudar para modo escuro"
   },
   "seo": {
-    "title": "Ulpio Netto \u2013 Desenvolvedor Backend | Go & Java | Engenheiro de Software",
-    "description": "Portfolio de Ulpio Netto, Desenvolvedor Backend com 5+ anos de experi\u00eancia em Go, Java, APIs REST, microsservi\u00e7os, Docker, Kubernetes e AWS."
+    "title": "Ulpio Netto – Desenvolvedor Backend | Go & Java | Engenheiro de Software",
+    "description": "Portfolio de Ulpio Netto, Desenvolvedor Backend com 5+ anos de experiência em Go, Java, APIs REST, microsserviços, Docker, Kubernetes e AWS."
+  },
+  "languages": {
+    "label": "// languages",
+    "title": "Idiomas",
+    "portuguese": "Português",
+    "english": "Inglês",
+    "mandarin": "Mandarim",
+    "native": "Nativo",
+    "fluent": "Fluente",
+    "beginner": "Iniciante (estudando)"
   }
 }

--- a/src/sections/AboutSection.jsx
+++ b/src/sections/AboutSection.jsx
@@ -38,6 +38,7 @@ function AboutSection() {
     ['email', t('about.terminal.email')],
     ['stack', t('about.terminal.stack')],
     ['open_to', t('about.terminal.openTo')],
+    ['languages', t('about.terminal.languages')],
   ];
 
   return (

--- a/src/sections/ExperienceSection.css
+++ b/src/sections/ExperienceSection.css
@@ -98,6 +98,10 @@
   font-weight: 700;
   color: var(--text-primary);
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .experience-card__period {
@@ -109,6 +113,28 @@
   border-radius: 9999px;
   padding: 0.2rem 0.6rem;
   white-space: nowrap;
+}
+
+.experience-card__type {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  border-radius: 9999px;
+  padding: 0.15rem 0.55rem;
+  white-space: nowrap;
+}
+
+.experience-card__type--freelance {
+  color: var(--accent-orange);
+  background: color-mix(in srgb, var(--accent-orange) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-orange) 25%, transparent);
+}
+
+.experience-card__type--personal {
+  color: var(--accent-green);
+  background: var(--accent-green-bg);
+  border: 1px solid var(--accent-green-border);
 }
 
 .experience-card__role {

--- a/src/sections/ExperienceSection.jsx
+++ b/src/sections/ExperienceSection.jsx
@@ -55,7 +55,14 @@ function ExperienceSection() {
                 <div className="experience-timeline__dot" aria-hidden="true" />
                 <article className="experience-card">
                   <header className="experience-card__header">
-                    <h3 className="experience-card__company">{exp.company}</h3>
+                    <h3 className="experience-card__company">
+                      {exp.company}
+                      {exp.type && (
+                        <span className={`experience-card__type experience-card__type--${exp.type.en === 'Freelance' ? 'freelance' : 'personal'}`}>
+                          {t(`experience.${exp.type.en === 'Freelance' ? 'freelance' : 'personalProject'}`)}
+                        </span>
+                      )}
+                    </h3>
                     <time className="experience-card__period">{exp.period}</time>
                   </header>
                   <p className="experience-card__role">{role}</p>


### PR DESCRIPTION
…oficiency

- guIA Travel Hub marked as Freelance with MVP context in highlights
- Vergo marked as Personal Project, positioned as reusable SaaS foundation
- Added languages: Portuguese (native), English (fluent), Mandarin (studying)
- Languages shown in About terminal, CV PDF, and i18n files (EN + PT-BR)
- Type badges (Freelance/Personal Project) in experience timeline cards