### PR TITLE
Humaniza copy + método XYZ (pt-BR/en), métricas verificadas e fix de imagens

### DIFF
--- a/src/data/cvData.js
+++ b/src/data/cvData.js
@@ -26,18 +26,18 @@ export const cvData = {
   },
 
   headline: {
-    en: 'Go \u00b7 Java \u00b7 REST APIs \u00b7 Microservices \u00b7 AWS \u00b7 Kubernetes',
-    pt: 'Go \u00b7 Java \u00b7 APIs REST \u00b7 Microsservi\u00e7os \u00b7 AWS \u00b7 Kubernetes',
+    en: 'Go · Java · REST APIs · Microservices · AWS · Kubernetes',
+    pt: 'Go · Java · APIs REST · Microsserviços · AWS · Kubernetes',
   },
 
   summary: {
     en: [
-      'Software Engineer with 5+ years of experience designing and building high-throughput REST APIs, microservices architectures, and cloud-native infrastructure. Proficient in Go (Golang), Java, PostgreSQL, Docker, Kubernetes, and AWS.',
-      'Proven track record of migrating legacy systems to modern stacks (achieving up to 75% faster response times), leading cross-functional teams, and shipping production systems serving 50k+ users. Strong focus on clean architecture, observability, and CI/CD best practices.',
+      'Software Engineer with 5+ years of experience designing and building REST APIs, microservices, and cloud-native infrastructure. Proficient in Go (Golang), Java, PostgreSQL/MySQL, Docker, Kubernetes, and AWS.',
+      'Track record of migrating legacy systems to modern stacks (up to 75% faster response times), leading a backend team, and shipping production systems for enterprise clients. Strong focus on clean architecture, observability, and CI/CD.',
     ],
     pt: [
-      'Engenheiro de Software com 5+ anos de experi\u00eancia projetando e construindo APIs REST de alta performance, arquiteturas de microsservi\u00e7os e infraestrutura cloud-native. Proficiente em Go (Golang), Java, PostgreSQL, Docker, Kubernetes e AWS.',
-      'Hist\u00f3rico comprovado em migra\u00e7\u00e3o de sistemas legados para stacks modernas (alcan\u00e7ando tempos de resposta at\u00e9 75% mais r\u00e1pidos), lideran\u00e7a de times multidisciplinares e entrega de sistemas em produ\u00e7\u00e3o servindo 50k+ usu\u00e1rios. Foco em arquitetura limpa, observabilidade e pr\u00e1ticas de CI/CD.',
+      'Engenheiro de Software com 5+ anos de experiência projetando e construindo APIs REST, microsserviços e infraestrutura cloud-native. Proficiente em Go (Golang), Java, PostgreSQL/MySQL, Docker, Kubernetes e AWS.',
+      'Histórico de migração de sistemas legados para stacks modernas (respostas até 75% mais rápidas), liderança de time de backend e entrega de sistemas em produção para clientes corporativos. Foco em arquitetura limpa, observabilidade e CI/CD.',
     ],
   },
 
@@ -48,7 +48,7 @@ export const cvData = {
     devops: ['AWS (EC2, S3, SQS, SNS, RDS)', 'Docker', 'Kubernetes', 'Terraform', 'Nginx', 'GitHub Actions', 'ArgoCD', 'CI/CD Pipelines'],
     practices: {
       en: ['Microservices Architecture', 'REST API Design', 'Event-Driven Architecture', 'Infrastructure as Code', 'GitOps', 'Observability (OpenTelemetry, Jaeger)', 'Agile / Scrum'],
-      pt: ['Arquitetura de Microsservi\u00e7os', 'Design de APIs REST', 'Arquitetura Orientada a Eventos', 'Infraestrutura como C\u00f3digo', 'GitOps', 'Observabilidade (OpenTelemetry, Jaeger)', '\u00c1gil / Scrum'],
+      pt: ['Arquitetura de Microsserviços', 'Design de APIs REST', 'Arquitetura Orientada a Eventos', 'Infraestrutura como Código', 'GitOps', 'Observabilidade (OpenTelemetry, Jaeger)', 'Ágil / Scrum'],
     },
   },
 
@@ -56,10 +56,10 @@ export const cvData = {
     {
       degree: {
         en: 'Bachelor of Computer Science',
-        pt: 'Bacharelado em Ci\u00eancia da Computa\u00e7\u00e3o',
+        pt: 'Bacharelado em Ciência da Computação',
       },
       institution: 'Afya Unima',
-      period: '2022 \u2013 2026',
+      period: '2022 – 2026',
     },
   ],
 
@@ -67,23 +67,25 @@ export const cvData = {
     {
       slug: 'yes',
       company: 'Yes Technology',
-      period: '2025 \u2013 Present',
+      period: '2025 – 2026',
       role: {
         en: 'Backend Developer | Software Engineer',
         pt: 'Desenvolvedor Backend | Engenheiro de Software',
       },
       highlights: {
         en: [
-          'Designed and built microservices in Go for PDF/XLS report generation integrated with a BPMN engine, handling 1000+ daily reports',
-          'Implemented event-driven communication via AWS SQS/SNS across distributed services',
-          'Deployed services on Kubernetes via ArgoCD (GitOps) with Terraform-managed infrastructure',
-          'Established observability stack with OpenTelemetry and Jaeger, reducing incident resolution time by 40%',
+          'Designed and shipped a field-level privacy system (LGPD) that audits 100% of sensitive-data access, with a justified-access flow, masking, and an audit trail in Go, rolled out gradually behind a feature flag',
+          'Built an asynchronous report-generation microservice in Go from scratch (PDF/XLS), processing hundreds of reports per month via AWS SQS/SNS, with S3 storage and a TypeScript CLI running on Kubernetes',
+          "Implemented object-level access control that met the client's compliance requirement, covering the MySQL schema, business logic, and UUID-traceable error messages, validated by integration tests",
+          'Evolved the MySQL master-data layer with dozens of versioned migrations (Objectclass/Relationclass model), fixing referential integrity and translations',
+          'Maintained the Kubernetes (Istio) deployment on AWS via Terraform and GitOps (ArgoCD), with distributed tracing (OpenTelemetry/Jaeger) and structured logging',
         ],
         pt: [
-          'Projetei e constru\u00ed microsservi\u00e7os em Go para gera\u00e7\u00e3o de relat\u00f3rios PDF/XLS integrados a motor BPMN, processando 1000+ relat\u00f3rios di\u00e1rios',
-          'Implementei comunica\u00e7\u00e3o orientada a eventos via AWS SQS/SNS entre servi\u00e7os distribu\u00eddos',
-          'Deploy de servi\u00e7os em Kubernetes via ArgoCD (GitOps) com infraestrutura gerenciada por Terraform',
-          'Estabeleci stack de observabilidade com OpenTelemetry e Jaeger, reduzindo tempo de resolu\u00e7\u00e3o de incidentes em 40%',
+          'Projetei e entreguei um sistema de privacidade a nível de campo (LGPD) que audita 100% dos acessos a dados sensíveis, com fluxo de acesso justificado, mascaramento e trilha de auditoria em Go, liberado gradualmente via feature-flag',
+          'Criei do zero um microsserviço em Go de geração assíncrona de relatórios (PDF/XLS), processando centenas de relatórios por mês via AWS SQS/SNS, com storage em S3 e um CLI TypeScript rodando em Kubernetes',
+          'Implementei controle de acesso a nível de objeto que atendeu a requisito de compliance do cliente, cobrindo schema MySQL, regra de negócio e erros rastreáveis por UUID, validado por testes de integração',
+          'Evoluí a camada de master data em MySQL com dezenas de migrations versionadas (modelo Objectclass/Relationclass), corrigindo integridade referencial e traduções',
+          'Sustentei o deploy em Kubernetes (Istio) na AWS via Terraform e GitOps (ArgoCD), com tracing distribuído (OpenTelemetry/Jaeger) e logs estruturados',
         ],
       },
     },
@@ -105,8 +107,8 @@ export const cvData = {
         ],
         pt: [
           'Contratado para arquitetar e entregar o MVP backend em Go/Java para plataforma de roteiros de viagem com IA',
-          'Constru\u00ed motor de gera\u00e7\u00e3o din\u00e2mica de itiner\u00e1rios integrando APIs externas de turismo e recomenda\u00e7\u00f5es de IA',
-          'Projetei schema PostgreSQL para gest\u00e3o de usu\u00e1rios multi-perfil (viajantes, ag\u00eancias)',
+          'Construí motor de geração dinâmica de itinerários integrando APIs externas de turismo e recomendações de IA',
+          'Projetei schema PostgreSQL para gestão de usuários multi-perfil (viajantes, agências)',
           'Deploy em AWS EC2 com S3 para armazenamento de assets e pipelines CI/CD automatizados',
         ],
       },
@@ -118,63 +120,61 @@ export const cvData = {
       period: '2025',
       role: {
         en: 'Creator & Lead Developer',
-        pt: 'Criador & Desenvolvedor L\u00edder',
+        pt: 'Criador & Desenvolvedor Líder',
       },
       highlights: {
         en: [
-          'Created a production-grade SaaS foundation in Go featuring multi-tenancy, RBAC, JWT auth, and Stripe billing — designed as a reusable base for any SaaS product',
+          'Created a production-grade SaaS foundation in Go featuring multi-tenancy, RBAC, JWT auth, and Stripe billing, designed as a reusable base for any SaaS product',
           'Implemented secure file handling with AWS S3 presigned URLs and project CRUD with full audit logging',
           'Engineered CI/CD with GitHub Actions, Dependabot, and CodeQL security scanning; open-sourced as a reference architecture',
         ],
         pt: [
-          'Criei uma base SaaS production-grade em Go com multi-tenancy, RBAC, auth JWT e billing Stripe — projetada como fundação reutilizável para qualquer produto SaaS',
-          'Implementei manipula\u00e7\u00e3o segura de arquivos com AWS S3 presigned URLs e CRUD de projetos com audit log completo',
-          'Configurei CI/CD com GitHub Actions, Dependabot para atualiza\u00e7\u00f5es e CodeQL para an\u00e1lise de seguran\u00e7a',
+          'Criei uma base SaaS production-grade em Go com multi-tenancy, RBAC, auth JWT e billing Stripe, projetada como fundação reutilizável para qualquer produto SaaS',
+          'Implementei manipulação segura de arquivos com AWS S3 presigned URLs e CRUD de projetos com audit log completo',
+          'Configurei CI/CD com GitHub Actions, Dependabot para atualizações e CodeQL para análise de segurança',
         ],
       },
     },
     {
       slug: 'registartt',
       company: 'Registartt',
-      period: '2024 \u2013 2025',
+      period: '2024 – 2025',
       role: {
         en: 'Backend Developer | Software Engineer',
         pt: 'Desenvolvedor Backend | Engenheiro de Software',
       },
       highlights: {
         en: [
-          'Built the entire backend from scratch in Go (Gin + SQLC), delivering a high-performance RESTful API',
-          'Designed authentication/authorization system and distributed caching layer for improved throughput',
-          'Implemented asynchronous task processing and structured logging with monitoring dashboards',
-          'Created interactive API documentation enabling seamless frontend integration',
+          'Built the platform backend from scratch in Go (Gin, SQLC), delivering a REST API with authentication and authorization',
+          'Designed a distributed caching layer and asynchronous task processing to improve throughput',
+          'Added structured logging with monitoring dashboards and interactive API documentation',
         ],
         pt: [
-          'Constru\u00ed todo o backend do zero em Go (Gin + SQLC), entregando API RESTful de alta performance',
-          'Projetei sistema de autentica\u00e7\u00e3o/autoriza\u00e7\u00e3o e camada de cache distribu\u00eddo para melhor throughput',
-          'Implementei processamento ass\u00edncrono de tarefas e logs estruturados com dashboards de monitoramento',
-          'Criei documenta\u00e7\u00e3o interativa da API possibilitando integra\u00e7\u00e3o seamless com frontend',
+          'Construí o backend da plataforma do zero em Go (Gin, SQLC), entregando uma API REST com autenticação e autorização',
+          'Projetei uma camada de cache distribuído e processamento assíncrono de tarefas para melhorar o throughput',
+          'Adicionei logs estruturados com dashboards de monitoramento e documentação interativa da API',
         ],
       },
     },
     {
       slug: 'oxetech',
       company: 'OxeTech (State Government of Alagoas)',
-      period: '2021 \u2013 2025',
+      period: '2021 – 2025',
       role: {
         en: 'Backend Developer | Team Lead',
         pt: 'Desenvolvedor Backend | Team Lead',
       },
       highlights: {
         en: [
-          'Migrated legacy JavaScript API to Go, achieving 75% faster response times and improved maintainability',
-          'Led a cross-functional team of 5+ developers, coordinating backend, frontend, and DevOps workflows',
-          'Designed and maintained microservices in Go, Java, and Node.js with PostgreSQL and MongoDB',
+          'Migrated a legacy JavaScript API to Go across 50+ endpoints, achieving up to 75% faster response times, as backend team lead',
+          'Led the backend team, coordinating backend, frontend, and DevOps workflows',
+          'Designed and maintained services in Go, Java, and Node.js with PostgreSQL and MongoDB',
           'Managed Docker/Kubernetes deployments on AWS with automated CI/CD pipelines',
         ],
         pt: [
-          'Migrei API legada em JavaScript para Go, alcan\u00e7ando tempos de resposta 75% mais r\u00e1pidos e melhor manutenibilidade',
-          'Liderei time multidisciplinar de 5+ devs, coordenando workflows de backend, frontend e DevOps',
-          'Projetei e mantive microsservi\u00e7os em Go, Java e Node.js com PostgreSQL e MongoDB',
+          'Migrei uma API legada em JavaScript para Go em 50+ endpoints, alcançando tempos de resposta até 75% mais rápidos, como team lead do backend',
+          'Liderei o time de backend, coordenando workflows de backend, frontend e DevOps',
+          'Projetei e mantive serviços em Go, Java e Node.js com PostgreSQL e MongoDB',
           'Gerenciei deploys Docker/Kubernetes na AWS com pipelines CI/CD automatizados',
         ],
       },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -22,9 +22,9 @@
   "about": {
     "label": "// about me",
     "title": "About Me",
-    "p1": "Backend Developer and Software Engineer focused on Go (Golang), Java, REST APIs, and microservices architecture. Solid experience with Docker, Kubernetes, AWS, PostgreSQL, and CI/CD pipelines.",
-    "p2": "Built backends for platforms like Registartt and guIA Travel Hub from scratch; contributed to projects like OxeTech, SonorIA, and Yes Technology. Experience in legacy database migration, REST API design, and team leadership.",
-    "p3": "Core stack: Go, Java, Node.js, PostgreSQL, MongoDB, AWS, Docker, Kubernetes, Terraform, and DevOps practices for secure and predictable deliveries.",
+    "p1": "Backend Developer and Software Engineer focused on Go, Java, REST APIs, and microservices architecture. I work with Docker, Kubernetes, AWS, PostgreSQL/MySQL, and CI/CD pipelines.",
+    "p2": "Built backends from scratch (Registartt, guIA Travel Hub) and worked on projects like OxeTech, SonorIA, and Yes Technology, including legacy database migration, REST API design, and technical team leadership.",
+    "p3": "Core stack: Go, Java, Node.js, PostgreSQL, MySQL, MongoDB, AWS, Docker, Kubernetes, Terraform, and DevOps practices for secure and predictable deliveries.",
     "stats": {
       "years": "years of experience",
       "projects": "projects delivered",
@@ -62,18 +62,17 @@
   },
   "projectData": {
     "registartt": {
-      "description": "Backend development for Registartt's online platform, providing a robust and scalable system for record management.",
+      "description": "Backend for Registartt's platform for record management, with a REST API, authentication, distributed caching, and asynchronous task processing.",
       "features": [
-        "High-performance RESTful API",
-        "Authentication and authorization system",
-        "Distributed cache for better performance",
+        "REST API with authentication and authorization",
+        "Distributed cache to reduce latency",
         "Asynchronous task processing",
         "Structured logging and monitoring",
         "Interactive API documentation"
       ]
     },
     "vergo": {
-      "description": "Open-source SaaS boilerplate in Go, featuring multi-tenancy, RBAC, JWT authentication, Postgres/sqlc integration, S3, and Stripe. Designed to demonstrate best practices in architecture, security, and CI/CD.",
+      "description": "Open-source SaaS boilerplate in Go, featuring multi-tenancy, RBAC, JWT authentication, Postgres/sqlc integration, S3, and Stripe. Demonstrates best practices in architecture, security, and CI/CD.",
       "features": [
         "JWT authentication (login, signup, refresh)",
         "RBAC (role-based access control)",
@@ -86,40 +85,41 @@
       ]
     },
     "oxetech": {
-      "description": "Platform for the State of Alagoas Government Program, democratizing access to technology education and development.",
+      "description": "Platform for the State of Alagoas Government Program for technology education. I rewrote the API from JavaScript to Go, with response times up to 75% faster and multiple access levels.",
       "features": [
-        "Migrated original API from JS to Go",
+        "Rewrote the API from JavaScript to Go",
         "Real-time data processing",
-        "Multiple access levels and business logic",
+        "Multiple access levels and business rules",
         "Response times up to 75% faster",
-        "Well-organized and maintainable API"
+        "Well-organized, maintainable API"
       ]
     },
     "guia": {
-      "description": "Smart tourism hub using AI to create personalized travel itineraries based on traveler profiles.",
+      "description": "Tourism hub that uses AI to build personalized travel itineraries based on the traveler's profile.",
       "features": [
         "Dynamic itinerary creation based on preferences and budget",
         "Complete itinerary export to PDF",
         "Traveler profile management",
-        "Smart suggestions for hotels, restaurants, and attractions",
+        "Suggestions for hotels, restaurants, and attractions",
         "Integration with external APIs for updated tourism data",
         "Daily itinerary organization with local tips"
       ]
     },
     "yes": {
-      "description": "Corporate microservices platform in Go for report generation (PDF/XLS) integrated with a BPMN engine, with distributed architecture and automated deployment on Kubernetes in AWS.",
+      "description": "Corporate low-code platform built around a BPMN engine, with a distributed Go backend on AWS. I worked on the platform core, built an asynchronous report-generation microservice (PDF/XLS), and evolved the master-data layer (MySQL). I also delivered a field-level privacy system, with justified access and auditing, aligned with Brazil's LGPD data-protection law.",
       "features": [
         "BPMN engine for business process orchestration",
-        "Asynchronous report generation in PDF and XLS",
-        "Inter-service communication via AWS SQS/SNS",
-        "Artifact storage on AWS S3",
-        "Kubernetes deployment via ArgoCD (GitOps)",
-        "Infrastructure as Code with Terraform",
-        "Observability with OpenTelemetry and Jaeger"
+        "Field-level privacy system (LGPD): justified access, sensitive-data masking, and an audit trail",
+        "Go microservice for asynchronous report generation in PDF and XLS",
+        "Object restriction with access control and UUID-traceable error messages",
+        "Event-driven inter-service communication via AWS SQS with SNS envelopes",
+        "MySQL master-data layer: Objectclass/Relationclass model and dozens of versioned migrations",
+        "Kubernetes (Istio) deployment on AWS with Terraform and GitOps via ArgoCD",
+        "Observability with distributed tracing (OpenTelemetry/Jaeger) and structured logging"
       ]
     },
     "sonoria": {
-      "description": "AI-powered web platform for automated analysis of auditory electrophysiological exams (PEATE, PEAC, VEMP), helping healthcare professionals in clinical decision-making.",
+      "description": "AI-powered web platform for automated analysis of auditory electrophysiological exams (PEATE, PEAC, VEMP), to support healthcare professionals in clinical decision-making.",
       "features": [
         "Automated auditory exam analysis with AI (CRNN model)",
         "Upload and processing of exam files (.txt)",
@@ -140,7 +140,11 @@
       "yes": {
         "role": "Backend Developer | Software Engineer",
         "highlights": [
-          "Building microservices in Go and Java; REST APIs; Docker and Kubernetes; AWS; CI/CD pipelines"
+          "Designed and shipped a field-level privacy system (LGPD) that audits 100% of sensitive-data access, with a justified-access flow, masking, and an audit trail in Go, rolled out gradually behind a feature flag",
+          "Built an asynchronous report-generation microservice in Go from scratch (PDF/XLS), processing hundreds of reports per month via AWS SQS/SNS, with S3 storage and a TypeScript CLI running on Kubernetes",
+          "Implemented object-level access control that met the client's compliance requirement, covering the MySQL schema, business logic, and UUID-traceable error messages, validated by integration tests",
+          "Evolved the MySQL master-data layer with dozens of versioned migrations (Objectclass/Relationclass model), fixing referential integrity and translations",
+          "Maintained the Kubernetes (Istio) deployment on AWS via Terraform and GitOps (ArgoCD), with distributed tracing (OpenTelemetry/Jaeger) and structured logging"
         ]
       },
       "guia": {
@@ -155,7 +159,7 @@
       "vergo": {
         "role": "Creator & Lead Developer",
         "highlights": [
-          "Created a production-grade SaaS foundation in Go featuring multi-tenancy, RBAC, JWT auth, and Stripe billing — designed as a reusable base for any SaaS product",
+          "Created a production-grade SaaS foundation in Go featuring multi-tenancy, RBAC, JWT auth, and Stripe billing, designed as a reusable base for any SaaS product",
           "Implemented secure file handling with AWS S3 presigned URLs and project CRUD with full audit logging",
           "Engineered CI/CD with GitHub Actions, Dependabot, and CodeQL security scanning; open-sourced as a reference architecture"
         ]
@@ -163,13 +167,18 @@
       "registartt": {
         "role": "Backend Developer | Software Engineer",
         "highlights": [
-          "Built platform backend from scratch; Go (Golang); REST APIs; PostgreSQL; Docker; AWS"
+          "Built the platform backend from scratch in Go (Gin, SQLC), delivering a REST API with authentication and authorization",
+          "Designed a distributed caching layer and asynchronous task processing to improve throughput",
+          "Added structured logging with monitoring dashboards and interactive API documentation"
         ]
       },
       "oxetech": {
-        "role": "Backend Developer | Software Engineer",
+        "role": "Backend Developer | Team Lead",
         "highlights": [
-          "Backend and microservices; Go, Java, and Node.js; REST APIs; PostgreSQL; Docker; Kubernetes; AWS; CI/CD; team lead"
+          "Migrated a legacy JavaScript API to Go across 50+ endpoints, achieving up to 75% faster response times, as backend team lead",
+          "Led the backend team, coordinating backend, frontend, and DevOps workflows",
+          "Designed and maintained services in Go, Java, and Node.js with PostgreSQL and MongoDB",
+          "Managed Docker/Kubernetes deployments on AWS with automated CI/CD pipelines"
         ]
       }
     },

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -22,9 +22,9 @@
   "about": {
     "label": "// about me",
     "title": "Sobre mim",
-    "p1": "Desenvolvedor Backend e Engenheiro de Software com foco em Go (Golang), Java, APIs REST e arquitetura de microsserviços. Experiência sólida com Docker, Kubernetes, AWS, PostgreSQL e pipelines de CI/CD.",
-    "p2": "Construí backends de plataformas como Registartt e guIA Travel Hub do zero; atuo em projetos como OxeTech, SonorIA e Yes Technology. Experiência em migração de bases legadas, design de APIs REST e gestão de times como team lead.",
-    "p3": "Stack principal: Go, Java, Node.js, PostgreSQL, MongoDB, AWS, Docker, Kubernetes, Terraform e práticas de DevOps para entregas seguras e previsíveis.",
+    "p1": "Desenvolvedor Backend e Engenheiro de Software com foco em Go, Java, APIs REST e arquitetura de microsserviços. Trabalho com Docker, Kubernetes, AWS, PostgreSQL/MySQL e pipelines de CI/CD.",
+    "p2": "Construí backends do zero (Registartt, guIA Travel Hub) e trabalhei em projetos como OxeTech, SonorIA e Yes Technology, com migração de bases legadas, design de APIs REST e liderança técnica de time.",
+    "p3": "Stack principal: Go, Java, Node.js, PostgreSQL, MySQL, MongoDB, AWS, Docker, Kubernetes, Terraform e práticas de DevOps para entregas seguras e previsíveis.",
     "stats": {
       "years": "anos de experiência",
       "projects": "projetos entregues",
@@ -62,18 +62,17 @@
   },
   "projectData": {
     "registartt": {
-      "description": "Desenvolvimento de backend para a plataforma online da Registartt, proporcionando um sistema robusto e escalável para gerenciamento de registros.",
+      "description": "Backend da plataforma da Registartt para gerenciamento de registros, com API REST, autenticação, cache distribuído e processamento assíncrono de tarefas.",
       "features": [
-        "API RESTful de alta performance",
-        "Sistema de autenticação e autorização",
-        "Cache distribuído para melhor desempenho",
+        "API REST com autenticação e autorização",
+        "Cache distribuído para reduzir latência",
         "Processamento assíncrono de tarefas",
         "Logs estruturados e monitoramento",
         "Documentação interativa da API"
       ]
     },
     "vergo": {
-      "description": "Boilerplate SaaS open source em Go, com foco em multi-tenant, RBAC, autenticação JWT, integração com Postgres/sqlc, S3 e Stripe. Projetado para demonstrar boas práticas de arquitetura, segurança e CI/CD.",
+      "description": "Boilerplate SaaS open source em Go, com foco em multi-tenant, RBAC, autenticação JWT, integração com Postgres/sqlc, S3 e Stripe. Demonstra boas práticas de arquitetura, segurança e CI/CD.",
       "features": [
         "Autenticação JWT (login, signup, refresh)",
         "RBAC (controle de acesso baseado em papéis)",
@@ -86,40 +85,41 @@
       ]
     },
     "oxetech": {
-      "description": "Plataforma do Programa do Governo do Estado de Alagoas, democratizando o acesso ao ensino de tecnologia e desenvolvimento.",
+      "description": "Plataforma do Governo do Estado de Alagoas para ensino de tecnologia. Reescrevi a API de JavaScript para Go, com respostas até 75% mais rápidas e diferentes níveis de acesso.",
       "features": [
-        "Transcrição da API original de JS para Go",
+        "Reescrita da API de JavaScript para Go",
         "Processamento de dados em tempo real",
-        "Diferentes níveis de acesso e lógicas de negócio",
-        "Tempos de resposta até 75% mais velozes",
-        "API organizada e de fácil manutenção"
+        "Diferentes níveis de acesso e regras de negócio",
+        "Respostas até 75% mais rápidas",
+        "API organizada e fácil de manter"
       ]
     },
     "guia": {
-      "description": "Hub de turismo inteligente que utiliza IA para montar roteiros de viagem personalizados a partir do perfil do viajante.",
+      "description": "Hub de turismo que usa IA para montar roteiros de viagem personalizados a partir do perfil do viajante.",
       "features": [
         "Criação de roteiros dinâmicos com base em preferências e orçamento",
         "Exportação de itinerários completos em PDF",
         "Cadastro e gestão de perfis de viajantes",
-        "Sugestões inteligentes de hotéis, restaurantes e atrações",
+        "Sugestões de hotéis, restaurantes e atrações",
         "Integração com APIs externas para dados atualizados de turismo",
         "Organização diária do roteiro com dicas locais"
       ]
     },
     "yes": {
-      "description": "Plataforma corporativa de microsserviços em Go para geração de relatórios (PDF/XLS) integrada a um motor BPMN, com arquitetura distribuída e deploy automatizado em Kubernetes na AWS.",
+      "description": "Plataforma corporativa low-code orientada a um motor BPMN, com backend distribuído em Go na AWS. Atuei no core da plataforma, criei um microsserviço de geração assíncrona de relatórios (PDF/XLS) e evoluí a camada de master data (MySQL). Entreguei também um sistema de privacidade a nível de campo, com acesso justificado e auditoria, alinhado à LGPD.",
       "features": [
         "Motor BPMN para orquestração de processos de negócio",
-        "Geração assíncrona de relatórios em PDF e XLS",
-        "Comunicação entre microsserviços via AWS SQS/SNS",
-        "Armazenamento de artefatos em AWS S3",
-        "Deploy em Kubernetes via ArgoCD (GitOps)",
-        "Infraestrutura como código com Terraform",
-        "Observabilidade com OpenTelemetry e Jaeger"
+        "Sistema de privacidade a nível de campo (LGPD): acesso justificado, mascaramento de dados sensíveis e trilha de auditoria",
+        "Microsserviço em Go para geração assíncrona de relatórios em PDF e XLS",
+        "Restrição de objetos (object restriction) com controle de acesso e erros rastreáveis por UUID",
+        "Comunicação event-driven entre microsserviços via AWS SQS com envelope SNS",
+        "Camada de master data em MySQL: modelo Objectclass/Relationclass e dezenas de migrations versionadas",
+        "Deploy em Kubernetes (Istio) na AWS com Terraform e GitOps via ArgoCD",
+        "Observabilidade com tracing distribuído (OpenTelemetry/Jaeger) e logs estruturados"
       ]
     },
     "sonoria": {
-      "description": "Plataforma web com IA para análise automatizada de exames eletrofisiológicos auditivos (PEATE, PEAC, VEMP), auxiliando profissionais de saúde na tomada de decisão clínica.",
+      "description": "Plataforma web com IA para análise automatizada de exames eletrofisiológicos auditivos (PEATE, PEAC, VEMP), para apoiar profissionais de saúde na decisão clínica.",
       "features": [
         "Análise automatizada de exames auditivos com IA (modelo CRNN)",
         "Upload e processamento de arquivos de exame (.txt)",
@@ -140,7 +140,11 @@
       "yes": {
         "role": "Desenvolvedor Backend | Engenheiro de Software",
         "highlights": [
-          "Backend em Go (Golang) e Java; APIs REST; microsserviços; Docker e Kubernetes; AWS; CI/CD."
+          "Projetei e entreguei um sistema de privacidade a nível de campo (LGPD) que audita 100% dos acessos a dados sensíveis, com fluxo de acesso justificado, mascaramento e trilha de auditoria em Go, liberado gradualmente via feature-flag",
+          "Criei do zero um microsserviço em Go de geração assíncrona de relatórios (PDF/XLS), processando centenas de relatórios por mês via AWS SQS/SNS, com storage em S3 e um CLI TypeScript rodando em Kubernetes",
+          "Implementei controle de acesso a nível de objeto que atendeu a requisito de compliance do cliente, cobrindo schema MySQL, regra de negócio e erros rastreáveis por UUID, validado por testes de integração",
+          "Evoluí a camada de master data em MySQL com dezenas de migrations versionadas (modelo Objectclass/Relationclass), corrigindo integridade referencial e traduções",
+          "Sustentei o deploy em Kubernetes (Istio) na AWS via Terraform e GitOps (ArgoCD), com observabilidade por tracing distribuído (OpenTelemetry/Jaeger) e logs estruturados"
         ]
       },
       "guia": {
@@ -155,7 +159,7 @@
       "vergo": {
         "role": "Criador & Desenvolvedor Líder",
         "highlights": [
-          "Criei uma base SaaS production-grade em Go com multi-tenancy, RBAC, auth JWT e billing Stripe — projetada como fundação reutilizável para qualquer produto SaaS",
+          "Criei uma base SaaS production-grade em Go com multi-tenancy, RBAC, auth JWT e billing Stripe, projetada como fundação reutilizável para qualquer produto SaaS",
           "Implementei manipulação segura de arquivos com AWS S3 presigned URLs e CRUD de projetos com audit log completo",
           "Implementei CI/CD com GitHub Actions, Dependabot e CodeQL para segurança; open-source como arquitetura de referência"
         ]
@@ -163,13 +167,18 @@
       "registartt": {
         "role": "Desenvolvedor Backend | Engenheiro de Software",
         "highlights": [
-          "Backend da plataforma do zero; Go (Golang); APIs REST; PostgreSQL; Docker; AWS."
+          "Construí o backend da plataforma do zero em Go (Gin, SQLC), entregando uma API REST com autenticação e autorização",
+          "Projetei uma camada de cache distribuído e processamento assíncrono de tarefas para melhorar o throughput",
+          "Adicionei logs estruturados com dashboards de monitoramento e documentação interativa da API"
         ]
       },
       "oxetech": {
-        "role": "Desenvolvedor Backend | Engenheiro de Software",
+        "role": "Desenvolvedor Backend | Team Lead",
         "highlights": [
-          "Backend e microsserviços; Go, Java e Node.js; APIs REST; PostgreSQL; Docker; Kubernetes; AWS; CI/CD; atuação como team lead."
+          "Migrei uma API legada em JavaScript para Go em 50+ endpoints, alcançando tempos de resposta até 75% mais rápidos, como team lead do backend",
+          "Liderei o time de backend, coordenando workflows de backend, frontend e DevOps",
+          "Projetei e mantive serviços em Go, Java e Node.js com PostgreSQL e MongoDB",
+          "Gerenciei deploys Docker/Kubernetes na AWS com pipelines CI/CD automatizados"
         ]
       }
     },

--- a/src/sections/ProjectsSection.css
+++ b/src/sections/ProjectsSection.css
@@ -77,6 +77,15 @@
   transform: scale(1.03);
 }
 
+/* Logos com proporção fora de 16:9 (muito larga ou quase quadrada): exibir
+   inteiros, sem recorte, num tile branco com respiro. */
+.project-card__image[data-slug="guia"],
+.project-card__image[data-slug="sonoria"] {
+  object-fit: contain;
+  background: #ffffff;
+  padding: 1.25rem 1.5rem;
+}
+
 .project-card__body {
   padding: 0 1.5rem 1.5rem;
   display: flex;

--- a/src/sections/ProjectsSection.jsx
+++ b/src/sections/ProjectsSection.jsx
@@ -42,6 +42,7 @@ function ProjectCard({ project }) {
           alt={project.title}
           loading="lazy"
           className="project-card__image"
+          data-slug={project.slug}
         />
       </div>
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -19,6 +19,7 @@
   --accent-green-bg: rgba(21, 128, 61, 0.1);
   --accent-green-border: rgba(21, 128, 61, 0.25);
   --accent-red: #dc2626;
+  --accent-orange: #d97706;
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
@@ -42,6 +43,7 @@
   --accent-green-bg: rgba(57, 211, 83, 0.1);
   --accent-green-border: rgba(57, 211, 83, 0.25);
   --accent-red: #f85149;
+  --accent-orange: #f59e0b;
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
## O que muda

Reescrita da copy do portfólio (página + PDF do CV) com **humanização** e o **método XYZ** do Google, em **pt-BR e en**.

### Conteúdo
- Descrições/features dos projetos e bullets de experiência reescritos no formato XYZ (resultado + métrica + como).
- Métricas ajustadas para valores **verificáveis** (integridade): Yes `2025–2026`, "centenas de relatórios/mês", compliance no object restriction, OxeTech "50+ endpoints / até 75% mais rápido".
- Removidas métricas não confirmadas que estavam no CV: `1000+ relatórios/dia`, `-40% incidentes`, `50k+ usuários`, `time de 5+`.
- Correção factual: banco **MySQL** (estava PostgreSQL na Yes).
- Página (i18n) e PDF (`cvData.js`) sincronizados; em-dashes e termos promocionais removidos.
- Telefone/WhatsApp preservado.

### Fix visual
- Logos da **guIA** e **SonorIA** agora aparecem inteiras (`object-fit: contain` + tile branco), sem recorte.

Inclui também o commit de tema (`--accent-orange`) do overhaul que ainda não estava na main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
